### PR TITLE
Do not exit on error if stdin or stdout have content

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,15 +164,14 @@ const spinnies = new Spinnies({
                 spinnies.update(file, { text: `√ built ${file}` });
             }
         } catch (error) {
-            // If there was an error with a subprocess that caused it to be
-            // killed forward that error, we don't know how to handle it.
-            if (error && error.failed) {
+            // If there was an error with a subprocess that had no output, exit.
+            if (error && error.failed && (!error.stderr && !error.stdout)) {
                 console.error(chalk.red(`There was an unexpected error building ${file}:\n\n${error.message}`));
                 process.exit(1);
             }
             // Output compilation errors.
             if (error && !error.isCanceled) {
-                spinnies.update(file, { text: chalk.red(`× error building ${file}\n ${error.stderr || error.stdout || error.message}`) });
+                spinnies.update(file, { text: chalk.red(`× error building ${file}\n ${error.stderr || error.stdout}`) });
             }
         }
     });

--- a/index.js
+++ b/index.js
@@ -164,15 +164,17 @@ const spinnies = new Spinnies({
                 spinnies.update(file, { text: `√ built ${file}` });
             }
         } catch (error) {
+            // Ignore cancelled subprocess.
+            if (error.isCanceled){
+                return;
+            }
             // If there was an error with a subprocess that had no output, exit.
-            if (error && error.failed && (!error.stderr && !error.stdout)) {
+            if (error.failed && (!error.stderr && !error.stdout)) {
                 console.error(chalk.red(`There was an unexpected error building ${file}:\n\n${error.message}`));
                 process.exit(1);
             }
-            // Output compilation errors.
-            if (error && !error.isCanceled) {
-                spinnies.update(file, { text: chalk.red(`× error building ${file}\n ${error.stderr || error.stdout}`) });
-            }
+            // Output other errors without existing, such as compilation errors.
+            spinnies.update(file, { text: chalk.red(`× error building ${file}\n ${error.stderr || error.stdout}`) });
         }
     });
 })();

--- a/test/integration/index.test.js
+++ b/test/integration/index.test.js
@@ -167,7 +167,7 @@ describe('origami-workshop', function () {
                     return;
                 }
                 try {
-                    // the build notice comes after
+                    // the build notice may come after the file is added
                     await sleep(100);
                     proclaim.include(commandOutput, 'built index.html');
                 } catch (error) {
@@ -232,14 +232,14 @@ describe('origami-workshop', function () {
                     return;
                 }
                 try {
-                    // the built contents is what we expect
-                    proclaim.include(fs.readFileSync(file, 'utf8'), 'background: red;');
-                    // the build notice comes after
+                    // the build notice may come after the file is added
                     await sleep(100);
                     proclaim.include(
                         commandOutput,
                         'built src/main.scss'
                     );
+                    // the built contents is what we expect
+                    proclaim.include(fs.readFileSync(file, 'utf8'), 'background: red;');
                 } catch (error) {
                     return done(error);
                 }
@@ -325,18 +325,18 @@ describe('origami-workshop', function () {
                     return;
                 }
                 try {
+                    // the build notice may come after the file is added
+                    await sleep(100);
+                    proclaim.include(
+                        commandOutput,
+                        'built src/main.js'
+                    );
                     // the built js is as expected
                     proclaim.include(fs.readFileSync(file, 'utf8'), jsCopy);
                     proclaim.doesNotInclude(
                         fs.readFileSync(file, 'utf8'),
                         jsImport,
                         'Expected JavaScript to be bundled.'
-                    );
-                    // the build notice comes after
-                    await sleep(100);
-                    proclaim.include(
-                        commandOutput,
-                        'built src/main.js'
                     );
                 } catch (error) {
                     return done(error);


### PR DESCRIPTION
At the moment compilation errors, which do have output, exit.
We could check exitCodes to be more specific, but as they may
change let's favour continuing to watch for changes on build
failures.