### PR TITLE
bugfix: make the "outputs a notice" test not call `done` multiple times

### DIFF
--- a/test/integration/index.test.js
+++ b/test/integration/index.test.js
@@ -110,7 +110,7 @@ describe('origami-workshop', function () {
 
         it('outputs a notice', function (done) {
             subprocess = runCommandUnderTest(done);
-            subprocess.all.on('data', chunk => {
+            subprocess.all.once('data', chunk => {
                 try {
                     proclaim.include(
                         chunk.toString('utf8'),


### PR DESCRIPTION
Calling `done` multiple times in a single test is not [supported in mocha](https://mochajs.org/#detects-multiple-calls-to-done), mocha throws an error.

If this test threw an error it would enter the catch block and call `done` and then leave the catch block and call `done` again.